### PR TITLE
🪲 [Fix]: Load prereqs before `Publish-PSResource`

### DIFF
--- a/scripts/helpers/Publish-PSModule.ps1
+++ b/scripts/helpers/Publish-PSModule.ps1
@@ -310,6 +310,13 @@ function Publish-PSModule {
     Stop-LogGroup
     #endregion Update module manifest
 
+    #region Install Prerequsites
+    Start-LogGroup 'Install module dependencies'
+    $manifestFilePath = Join-Path -Path $Path -ChildPath "$moduleName.psd1"
+    Resolve-PSModuleDependency -ManifestFilePath $manifestFilePath
+    Stop-LogGroup
+    #endregion Install Prerequsites
+
     #region Create releases
     if ($createPrerelease -or $createRelease -or $whatIf) {
         #region Publish-ToPSGallery

--- a/scripts/helpers/Publish-PSModule.ps1
+++ b/scripts/helpers/Publish-PSModule.ps1
@@ -321,7 +321,7 @@ function Publish-PSModule {
             try {
                 Publish-PSResource -Path $ModulePath -Repository PSGallery -ApiKey $APIKey -Verbose
             } catch {
-                Write-Error 'Failed to publish the module to the PowerShell Gallery.'
+                Write-Error $_.Exception.Message
                 exit $LASTEXITCODE
             }
         }

--- a/scripts/helpers/Publish-PSModule.ps1
+++ b/scripts/helpers/Publish-PSModule.ps1
@@ -312,7 +312,6 @@ function Publish-PSModule {
 
     #region Install Prerequsites
     Start-LogGroup 'Install module dependencies'
-    $manifestFilePath = Join-Path -Path $Path -ChildPath "$moduleName.psd1"
     Resolve-PSModuleDependency -ManifestFilePath $manifestFilePath
     Stop-LogGroup
     #endregion Install Prerequsites

--- a/scripts/helpers/Resolve-PSModuleDependency.ps1
+++ b/scripts/helpers/Resolve-PSModuleDependency.ps1
@@ -1,0 +1,60 @@
+﻿function Resolve-PSModuleDependency {
+    <#
+        .SYNOPSIS
+        Resolve dependencies for a module based on the manifest file.
+
+        .DESCRIPTION
+        Resolve dependencies for a module based on the manifest file, following PSModuleInfo structure
+
+        .EXAMPLE
+        Resolve-PSModuleDependency -Path 'C:\MyModule\MyModule.psd1'
+
+        Installs all modules defined in the manifest file, following PSModuleInfo structure.
+
+        .NOTES
+        Should later be adapted to support both pre-reqs, and dependencies.
+        Should later be adapted to take 4 parameters sets: specific version ("requiredVersion" | "GUID"), latest version ModuleVersion,
+        and latest version within a range MinimumVersion - MaximumVersion.
+    #>
+    [Alias('Resolve-PSModuleDependencies')]
+    [CmdletBinding()]
+    param(
+        # The path to the manifest file.
+        [Parameter(Mandatory)]
+        [string] $ManifestFilePath
+    )
+
+    Write-Verbose 'Resolving dependencies'
+
+    $manifest = Import-PowerShellDataFile -Path $ManifestFilePath
+    Write-Verbose "Reading [$ManifestFilePath]"
+    Write-Verbose "Found [$($manifest.RequiredModules.Count)] modules to install"
+
+    foreach ($requiredModule in $manifest.RequiredModules) {
+        $installParams = @{}
+
+        if ($requiredModule -is [string]) {
+            $installParams.Name = $requiredModule
+        } else {
+            $installParams.Name = $requiredModule.ModuleName
+            $installParams.MinimumVersion = $requiredModule.ModuleVersion
+            $installParams.RequiredVersion = $requiredModule.RequiredVersion
+            $installParams.MaximumVersion = $requiredModule.MaximumVersion
+        }
+        $installParams.Force = $true
+        $installParams.Verbose = $false
+
+        Write-Verbose "[$($installParams.Name)] - Installing module"
+        $VerbosePreferenceOriginal = $VerbosePreference
+        $VerbosePreference = 'SilentlyContinue'
+        Install-Module @installParams -AllowPrerelease:$false
+        $VerbosePreference = $VerbosePreferenceOriginal
+        Write-Verbose "[$($installParams.Name)] - Importing module"
+        $VerbosePreferenceOriginal = $VerbosePreference
+        $VerbosePreference = 'SilentlyContinue'
+        Import-Module @installParams
+        $VerbosePreference = $VerbosePreferenceOriginal
+        Write-Verbose "[$($installParams.Name)] - Done"
+    }
+    Write-Verbose 'Resolving dependencies - Done'
+}


### PR DESCRIPTION
## Description

- Load prereqs before `Publish-PSResource`

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
