### PR TITLE
🩹 [Patch]: Move to GitHub-Script

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,3 @@ updates:
     directory: / # Location of package manifests
     schedule:
       interval: weekly
-  - package-ecosystem: nuget # See documentation for possible values
-    directory: / # Location of package manifests
-    schedule:
-      interval: weekly

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -2,7 +2,11 @@ name: Action-Test
 
 run-name: "Action-Test - [${{ github.event.pull_request.title }} #${{ github.event.pull_request.number }}] by @${{ github.actor }}"
 
-on: [pull_request]
+on:
+  workflow_dispatch:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -32,6 +32,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
+          Verbose: true
+          Debug: true
           Name: PSModuleTest
           ModulePath: tests/outputs/modules
           APIKey: ${{ secrets.APIKEY }}

--- a/README.md
+++ b/README.md
@@ -45,22 +45,26 @@ prereleases that was created.
 
 The action can be configured using the following settings:
 
-| Name | Description | Default | Required |
+| Name | Description | Required | Default |
 | --- | --- | --- | --- |
-| `APIKey` | PowerShell Gallery API Key. | | true |
-| `AutoCleanup`| Control wether to automatically cleanup prereleases. If disabled, the action will not remove any prereleases. | `true` | false |
-| `AutoPatching` | Control wether to automatically handle patches. If disabled, the action will only create a patch release if the pull request has a 'patch' label. | `true` | false |
-| `ConfigurationFile` | The path to the configuration file. Settings in the configuration file take precedence over the action inputs. | `.github\auto-release.yml` | false |
-| `DatePrereleaseFormat` | The format to use for the prerelease number using [.NET DateTime format strings](https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings). | `''` | false |
-| `IgnoreLabels` | A comma separated list of labels that do not trigger a release. | `NoRelease` | false |
-| `IncrementalPrerelease` | Control wether to automatically increment the prerelease number. If disabled, the action will ensure only one prerelease exists for a given branch. | `true` | false |
-| `MajorLabels` | A comma separated list of labels that trigger a major release. | `major, breaking` | false |
-| `MinorLabels` | A comma separated list of labels that trigger a minor release. | `minor, feature` | false |
-| `ModulePath` | Path to the folder where the module to publish is located. | `outputs/modules` | false |
-| `Name` | Name of the module to publish. Defaults to the repository name. | | false |
-| `PatchLabels` | A comma separated list of labels that trigger a patch release. | `patch, fix` | false |
-| `VersionPrefix` | The prefix to use for the version number. | `v` | false |
-| `WhatIf` | Control wether to simulate the action. If enabled, the action will not create any releases. Used for testing. | `false` | false |
+| `APIKey` | PowerShell Gallery API Key. | `true` | |
+| `AutoCleanup`| Control wether to automatically cleanup prereleases. If disabled, the action will not remove any prereleases. | `false` | `true` |
+| `AutoPatching` | Control wether to automatically handle patches. If disabled, the action will only create a patch release if the pull request has a 'patch' label. | `false` | `true` |
+| `ConfigurationFile` | The path to the configuration file. Settings in the configuration file take precedence over the action inputs. | `false` | `.github\auto-release.yml` |
+| `DatePrereleaseFormat` | The format to use for the prerelease number using [.NET DateTime format strings](https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings). | `false` | `''` |
+| `IgnoreLabels` | A comma separated list of labels that do not trigger a release. | `false` | `NoRelease` |
+| `IncrementalPrerelease` | Control wether to automatically increment the prerelease number. If disabled, the action will ensure only one prerelease exists for a given branch. | `false` | `true` |
+| `MajorLabels` | A comma separated list of labels that trigger a major release. | `false` | `major, breaking` |
+| `MinorLabels` | A comma separated list of labels that trigger a minor release. | `false` | `minor, feature` |
+| `ModulePath` | Path to the folder where the module to publish is located. | `false` | `outputs/modules` |
+| `Name` | Name of the module to publish. Defaults to the repository name. | `false` | |
+| `PatchLabels` | A comma separated list of labels that trigger a patch release. | `false` | `patch, fix` |
+| `VersionPrefix` | The prefix to use for the version number. | `false` | `v` |
+| `WhatIf` | Control wether to simulate the action. If enabled, the action will not create any releases. Used for testing. | `false` | `false` |
+| `Debug` | Enable debug output. | `'false'` | `false` |
+| `Verbose` | Enable verbose output. | `'false'` | `false` |
+| `Version` | Specifies the version of the GitHub module to be installed. The value must be an exact version. | | `false` |
+| `Prerelease` | Allow prerelease versions if available. | `'false'` | `false` |
 
 ### Configuration file
 

--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,21 @@ inputs:
     description: If specified, the action will only log the changes it would make, but will not actually create or delete any releases or tags.
     required: false
     default: 'false'
+  Debug:
+    description: Enable debug output.
+    required: false
+    default: 'false'
+  Verbose:
+    description: Enable verbose output.
+    required: false
+    default: 'false'
+  Version:
+    description: Specifies the version of the GitHub module to be installed. The value must be an exact version.
+    required: false
+  Prerelease:
+    description: Allow prerelease versions if available.
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -82,6 +97,10 @@ runs:
         GITHUB_ACTION_INPUT_VersionPrefix: ${{ inputs.VersionPrefix }}
         GITHUB_ACTION_INPUT_WhatIf: ${{ inputs.WhatIf }}
       with:
+        Debug: ${{ inputs.Debug }}
+        Prerelease: ${{ inputs.Prerelease }}
+        Verbose: ${{ inputs.Verbose }}
+        Version: ${{ inputs.Version }}
         Script: |
           # Publish-PSModule
-          . "$env:GITHUB_ACTION_PATH\scripts\main.ps1" -Verbose
+          . "$env:GITHUB_ACTION_PATH\scripts\main.ps1"

--- a/action.yml
+++ b/action.yml
@@ -66,9 +66,6 @@ runs:
   steps:
     - name: Run Build-PSModule
       uses: PSModule/GitHub-Script@v1
-
-    - name: Run Publish-PSModule
-      shell: pwsh
       env:
         GITHUB_ACTION_INPUT_Name: ${{ inputs.Name }}
         GITHUB_ACTION_INPUT_ModulePath: ${{ inputs.ModulePath }}
@@ -84,6 +81,7 @@ runs:
         GITHUB_ACTION_INPUT_PatchLabels: ${{ inputs.PatchLabels }}
         GITHUB_ACTION_INPUT_VersionPrefix: ${{ inputs.VersionPrefix }}
         GITHUB_ACTION_INPUT_WhatIf: ${{ inputs.WhatIf }}
-      run: |
-        # Publish-PSModule
-        . "$env:GITHUB_ACTION_PATH\scripts\main.ps1" -Verbose
+      with:
+        Script: |
+          # Publish-PSModule
+          . "$env:GITHUB_ACTION_PATH\scripts\main.ps1" -Verbose

--- a/action.yml
+++ b/action.yml
@@ -103,4 +103,4 @@ runs:
         Version: ${{ inputs.Version }}
         Script: |
           # Publish-PSModule
-          . "$env:GITHUB_ACTION_PATH\scripts\main.ps1"
+          . "${{ github.action_path }}\scripts\main.ps1"

--- a/scripts/helpers/Publish-PSModule.ps1
+++ b/scripts/helpers/Publish-PSModule.ps1
@@ -309,7 +309,7 @@ function Publish-PSModule {
                 Write-Verbose "Publish-PSResource -Path $ModulePath -Repository PSGallery -ApiKey $APIKey -Verbose"
             } else {
                 try {
-                    Publish-PSResource -Path $ModulePath -Repository PSGallery -ApiKey $APIKey -Verbose
+                    Publish-PSResource -Path $ModulePath -Repository PSGallery -ApiKey $APIKey
                 } catch {
                     Write-Error $_.Exception.Message
                     exit $LASTEXITCODE

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -31,4 +31,4 @@ $params = @{
     ModulePath = $modulePath
     APIKey     = $env:GITHUB_ACTION_INPUT_APIKey
 }
-Publish-PSModule @params -Verbose
+Publish-PSModule @params

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -1,10 +1,12 @@
 [CmdletBinding()]
 param()
 
-$path = (Join-Path -Path $env:GITHUB_ACTION_PATH -ChildPath 'scripts' 'helpers')
+$path = (Join-Path -Path $PSScriptRoot -ChildPath 'helpers')
 LogGroup "Loading helper scripts from [$path]" {
-    Get-ChildItem -Path $path -Filter '*.ps1' -Recurse |
-        ForEach-Object { Write-Verbose "[$($_.FullName)]"; . $_.FullName }
+    Get-ChildItem -Path $path -Filter '*.ps1' -Recurse | ForEach-Object {
+        Write-Verbose "[$($_.FullName)]"
+        . $_.FullName
+    }
 }
 
 LogGroup 'Loading inputs' {


### PR DESCRIPTION
## Description


This pull request includes several changes to the GitHub Actions workflow, configuration files, and scripts to improve functionality and consistency. The most important changes include the addition of new inputs and options for the action, updates to the workflow triggers, and modifications to the README for clarity.

### Workflow and Configuration Updates:

* [`.github/workflows/Action-Test.yml`](diffhunk://#diff-a12ae5c885b0673c0ff6f70c2670886907590d624626e07da4c52e01aeaf56a4L5-R9): Added `workflow_dispatch` and `schedule` triggers to the workflow. Enabled `Verbose` and `Debug` options in the `jobs` section. [[1]](diffhunk://#diff-a12ae5c885b0673c0ff6f70c2670886907590d624626e07da4c52e01aeaf56a4L5-R9) [[2]](diffhunk://#diff-a12ae5c885b0673c0ff6f70c2670886907590d624626e07da4c52e01aeaf56a4R35-R36)
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L12-L15): Removed redundant `nuget` package-ecosystem configuration.

### README and Documentation:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L48-R67): Reordered columns in the configuration table for better readability. Added new configuration options `Debug`, `Verbose`, `Version`, and `Prerelease`.

### Action Inputs:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R63-L71): Added new inputs `Debug`, `Verbose`, `Version`, and `Prerelease` to the action configuration. Updated the `runs` section to pass these inputs to the script. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R63-L71) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L87-R106)

### Script Enhancements:

* [`scripts/main.ps1`](diffhunk://#diff-dc2e5a659836b1b73abb03421c567f5018c2755677c4a0aa764cb26117b68011L4-R9): Changed the script to load helper scripts from `$PSScriptRoot` instead of `$env:GITHUB_ACTION_PATH`. Removed the `-Verbose` flag from `Publish-PSModule` call. [[1]](diffhunk://#diff-dc2e5a659836b1b73abb03421c567f5018c2755677c4a0aa764cb26117b68011L4-R9) [[2]](diffhunk://#diff-dc2e5a659836b1b73abb03421c567f5018c2755677c4a0aa764cb26117b68011L32-R34)
* [`scripts/helpers/Publish-PSModule.ps1`](diffhunk://#diff-780715ac24c6bbe21b54f3d268778136b79f21a62275bbd494dfa857b4ba40d9L312-R312): Removed the `-Verbose` flag from the `Publish-PSResource` command.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
