### PR TITLE
🩹 [Patch]: Add Retry on Install-Module

### DIFF
--- a/scripts/helpers/Resolve-PSModuleDependency.ps1
+++ b/scripts/helpers/Resolve-PSModuleDependency.ps1
@@ -1,4 +1,6 @@
-﻿function Resolve-PSModuleDependency {
+﻿#Requires -Modules Retry
+
+function Resolve-PSModuleDependency {
     <#
         .SYNOPSIS
         Resolve dependencies for a module based on the manifest file.
@@ -47,7 +49,9 @@
         Write-Verbose "[$($installParams.Name)] - Installing module"
         $VerbosePreferenceOriginal = $VerbosePreference
         $VerbosePreference = 'SilentlyContinue'
-        Install-Module @installParams -AllowPrerelease:$false
+        Retry -Count 5 -Delay 10 {
+            Install-Module @installParams -AllowPrerelease:$false
+        }
         $VerbosePreference = $VerbosePreferenceOriginal
         Write-Verbose "[$($installParams.Name)] - Importing module"
         $VerbosePreferenceOriginal = $VerbosePreference


### PR DESCRIPTION
## Description

This pull request includes changes to the `Resolve-PSModuleDependency.ps1` script to enhance its reliability by adding retry logic for module installations.

Enhancements to module installation reliability:

* [`scripts/helpers/Resolve-PSModuleDependency.ps1`](diffhunk://#diff-48557b471e7d62a89be3627235334ab8a39eb6119174abb61714b92d844508e2L1-R3): Added a `#Requires` statement to ensure the `Retry` module is available.
* [`scripts/helpers/Resolve-PSModuleDependency.ps1`](diffhunk://#diff-48557b471e7d62a89be3627235334ab8a39eb6119174abb61714b92d844508e2R52-R54): Wrapped the `Install-Module` command with a `Retry` block to attempt installation up to 5 times with a 10-second delay between attempts.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
