### PR TITLE
🚀 [Feature]: Add padding to the prerelease number

### DIFF
--- a/scripts/helpers/Publish-PSModule.ps1
+++ b/scripts/helpers/Publish-PSModule.ps1
@@ -275,6 +275,7 @@ function Publish-PSModule {
 
                 $latestPrereleaseNumber = [Math]::Max($latestPSGalleryPrerelease, $latestGHPrereleases)
                 $latestPrereleaseNumber++
+                $latestPrereleaseNumber = $latestPrereleaseNumber.PadLeft(3,'0')
                 $newVersion.Prerelease += $latestPrereleaseNumber
             }
         }


### PR DESCRIPTION
## Description

This pull request includes a small change to the `Publish-PSModule` function in the `scripts/helpers/Publish-PSModule.ps1` file. The change ensures that the latest prerelease number is padded to three digits for consistency.

* [`scripts/helpers/Publish-PSModule.ps1`](diffhunk://#diff-780715ac24c6bbe21b54f3d268778136b79f21a62275bbd494dfa857b4ba40d9R278): Added padding to the `latestPrereleaseNumber` to ensure it is three digits long.
  * Fixes #38

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [x] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
