### PR TITLE
🩹 [Patch]: Remove initialization step and dependency on `Utilities`

### DIFF
--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -24,9 +24,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Initialize environment
-        uses: PSModule/Initialize-PSModule@main
-
       - name: Action-Test
         uses: ./
         env:

--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,7 @@ runs:
   using: composite
   steps:
     - name: Install-PSModuleHelpers
-      uses: PSModule/Install-PSModuleHelpers@v1
+      uses: PSModule/Install-PSModuleHelpers@removeInit
 
     - name: Run Publish-PSModule
       uses: PSModule/GitHub-Script@v1

--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,7 @@ runs:
   using: composite
   steps:
     - name: Install-PSModuleHelpers
-      uses: PSModule/Install-PSModuleHelpers@removeInit
+      uses: PSModule/Install-PSModuleHelpers@v1
 
     - name: Run Publish-PSModule
       uses: PSModule/GitHub-Script@v1

--- a/scripts/helpers/Publish-PSModule.ps1
+++ b/scripts/helpers/Publish-PSModule.ps1
@@ -11,7 +11,6 @@
     #>
     [OutputType([void])]
     [CmdletBinding()]
-    #Requires -Modules Utilities, PowerShellGet, Microsoft.PowerShell.PSResourceGet, GitHub, PSSemVer
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
         'PSReviewUnusedParameter', '', Scope = 'Function',
         Justification = 'LogGroup - Scoping affects the variables line of sight.'

--- a/scripts/helpers/Publish-PSModule.ps1
+++ b/scripts/helpers/Publish-PSModule.ps1
@@ -145,7 +145,7 @@
         $latestRelease = $releases | Where-Object { $_.isLatest -eq $true }
         $latestRelease | Format-List | Out-String
         $ghReleaseVersionString = $latestRelease.tagName
-        if ($ghReleaseVersionString | IsNotNullOrEmpty) {
+        if (-not [string]::IsNullOrEmpty($ghReleaseVersionString)) {
             $ghReleaseVersion = New-PSSemVer -Version $ghReleaseVersionString
         } else {
             Write-Warning 'Could not find the latest release version. Using ''0.0.0'' as the version.'
@@ -197,7 +197,7 @@
         try {
             $manifestVersion = New-PSSemVer -Version (Test-ModuleManifest $manifestFilePath -Verbose:$false).Version
         } catch {
-            if ($manifestVersion | IsNullOrEmpty) {
+            if ([string]::IsNullOrEmpty($manifestVersion)) {
                 Write-Warning 'Could not find the module version in the manifest. Using ''0.0.0'' as the version.'
                 $manifestVersion = New-PSSemVer -Version '0.0.0'
             }
@@ -248,7 +248,7 @@
             $newVersion.Prerelease = $prereleaseName
             Write-Output "Partial new version: [$newVersion]"
 
-            if ($datePrereleaseFormat | IsNotNullOrEmpty) {
+            if (-not [string]::IsNullOrEmpty($datePrereleaseFormat)) {
                 Write-Output "Using date-based prerelease: [$datePrereleaseFormat]."
                 $newVersion.Prerelease += "$(Get-Date -Format $datePrereleaseFormat)"
                 Write-Output "Partial new version: [$newVersion]"

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -1,6 +1,22 @@
 [CmdletBinding()]
 param()
 
+$retryCount = 5
+$retryDelay = 10
+for ($i = 0; $i -lt $retryCount; $i++) {
+    try {
+        Install-PSResource -Name 'PSSemVer' -TrustRepository -Repository PSGallery
+        break
+    } catch {
+        Write-Warning "Installation of $($psResourceParams.Name) failed with error: $_"
+        if ($i -eq $retryCount - 1) {
+            throw
+        }
+        Write-Warning "Retrying in $retryDelay seconds..."
+        Start-Sleep -Seconds $retryDelay
+    }
+}
+
 $path = (Join-Path -Path $PSScriptRoot -ChildPath 'helpers')
 LogGroup "Loading helper scripts from [$path]" {
     Get-ChildItem -Path $path -Filter '*.ps1' -Recurse | ForEach-Object {


### PR DESCRIPTION
## Description

Remove the initialization step and dependency on `Utilities`, the Install-PSModuleHelpers takes over.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
