### PR TITLE
📖 [Docs]: Remove unused configuration options from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,6 @@ The action can be configured using the following settings:
 | `PatchLabels` | A comma separated list of labels that trigger a patch release. | `false` | `patch, fix` |
 | `IgnoreLabels` | A comma separated list of labels that do not trigger a release. | `false` | `NoRelease` |
 | `WhatIf` | Control wether to simulate the action. If enabled, the action will not create any releases. Used for testing. | `false` | `false` |
-| `Debug` | Enable debug output. | `'false'` | `false` |
-| `Verbose` | Enable verbose output. | `'false'` | `false` |
-| `Version` | Specifies the version of the GitHub module to be installed. The value must be an exact version. | | `false` |
-| `Prerelease` | Allow prerelease versions if available. | `'false'` | `false` |
 | `WorkingDirectory` | The working directory where the script runs. | `'false'`    | `'.'` |
 
 ## Example

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -25,6 +25,8 @@ Set-GitHubLogGroup "Loading helper scripts from [$path]" {
     }
 }
 
+$env:GITHUB_REPOSITORY_NAME = $env:GITHUB_REPOSITORY -replace '.+/'
+
 Set-GitHubLogGroup 'Loading inputs' {
     $name = if ([string]::IsNullOrEmpty($env:PSMODULE_PUBLISH_PSMODULE_INPUT_Name)) {
         $env:GITHUB_REPOSITORY_NAME


### PR DESCRIPTION
## Description

This pull request updates the `README.md` file to simplify the list of configurable settings for the action. It removes several less commonly used settings to streamline the documentation and make it easier to read.

Documentation cleanup:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L63-L66): Removed the following settings from the configuration list: `Debug`, `Verbose`, `Version`, and `Prerelease`. These settings are no longer included in the documentation to simplify the list and focus on the most relevant options.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
