### PR TITLE
🩹 [Patch]: Encode all PowerShell files using UTF8 with BOM

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -1,4 +1,4 @@
-[CmdletBinding()]
+﻿[CmdletBinding()]
 param()
 
 $retryCount = 5


### PR DESCRIPTION
## Description

This pull request makes a minor change to the `scripts/main.ps1` file. It updates the file to include a Unicode Byte Order Mark (BOM) at the beginning, which can help with encoding detection in some editors and environments.