### PR TITLE
⚙️ [Maintenance]: Align release workflow

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -28,7 +28,7 @@ jobs:
   Release:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
+      - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -21,8 +21,8 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: write # Required to create releases
+  pull-requests: write # Required to create comments on the PRs
 
 jobs:
   Release:
@@ -34,6 +34,4 @@ jobs:
           persist-credentials: false
 
       - name: Release
-        uses: PSModule/Release-GHRepository@88c70461c8f16cc09682005bcf3b7fca4dd8dc1a # v2.0.1
-        with:
-          IncrementalPrerelease: false
+        uses: PSModule/Release-GHRepository@5a5165d66f485d1aad217ef34a190178b214fdcb # v2.0.2

--- a/action.yml
+++ b/action.yml
@@ -78,7 +78,7 @@ runs:
   using: composite
   steps:
     - name: Install-PSModuleHelpers
-      uses: PSModule/Install-PSModuleHelpers@d60d63e4be477d1ca0c67c6085101fb109bce8f1 # v1.0.6
+      uses: PSModule/Install-PSModuleHelpers@ed79b6e3aa8c9cd3d30ab2bf02ea6bd4687b9c74 # v1.0.7
 
     - name: Update Microsoft.PowerShell.PSResourceGet
       shell: pwsh


### PR DESCRIPTION
The Release workflow has been updated to standardize step naming conventions across all PSModule repositories, improving consistency and maintainability.

## Standardized step naming

The checkout step in the Release workflow has been renamed from "Checkout Code" to "Checkout repo" to align with the naming convention used across all PSModule action repositories.