### PR TITLE
⚙️ [Maintenance]: Update super-linter to v8.4.0

### DIFF
--- a/.github/linters/.codespellrc
+++ b/.github/linters/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+skip = ./.github/linters

--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -28,7 +28,6 @@ jobs:
         uses: super-linter/super-linter@12562e48d7059cf666c43a4ecb0d3b5a2b31bd9e # v8.4.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          SUPPRESS_OUTPUT_ON_SUCCESS: true
           VALIDATE_BIOME_FORMAT: false
           VALIDATE_JSCPD: false
           VALIDATE_JSON_PRETTIER: false

--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -25,9 +25,10 @@ jobs:
           persist-credentials: false
 
       - name: Lint code base
-        uses: super-linter/super-linter@d5b0a2ab116623730dd094f15ddc1b6b25bf7b99 # v8.3.2
+        uses: super-linter/super-linter@12562e48d7059cf666c43a4ecb0d3b5a2b31bd9e # v8.4.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          SUPPRESS_OUTPUT_ON_SUCCESS: true
           VALIDATE_BIOME_FORMAT: false
           VALIDATE_JSCPD: false
           VALIDATE_JSON_PRETTIER: false

--- a/src/publish.ps1
+++ b/src/publish.ps1
@@ -57,6 +57,7 @@ LogGroup 'Load publish context from environment' {
 
     Write-Host '-------------------------------------------------'
     [PSCustomObject]@{
+        ShouldPublish    = $shouldPublish
         CreateRelease    = $createRelease
         CreatePrerelease = $createPrerelease
         NewVersion       = $newVersion.ToString()

--- a/src/publish.ps1
+++ b/src/publish.ps1
@@ -37,6 +37,7 @@ LogGroup 'Load inputs' {
 }
 
 LogGroup 'Load publish context from environment' {
+    $shouldPublish = $env:PUBLISH_CONTEXT_ShouldPublish -eq 'true'
     $createRelease = $env:PUBLISH_CONTEXT_CreateRelease -eq 'true'
     $createPrerelease = $env:PUBLISH_CONTEXT_CreatePrerelease -eq 'true'
     $newVersionString = $env:PUBLISH_CONTEXT_NewVersion


### PR DESCRIPTION
## Description

Updates super-linter from v8.3.2 to v8.4.0.

## Changes

- Updated `super-linter/super-linter` to v8.4.0 (`12562e48d7059cf666c43a4ecb0d3b5a2b31bd9e`)
- Added `.codespellrc` configuration file for codespell linter

## References

- [super-linter v8.4.0 release](https://github.com/super-linter/super-linter/releases/tag/v8.4.0)